### PR TITLE
extmod/vfs_lfsx.c: Fix a few minor error in vfs_lfsx

### DIFF
--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -34,7 +34,7 @@
 #include "py/mperrno.h"
 #include "extmod/vfs.h"
 
-STATIC int MP_VFS_LFSx(dev_ioctl)(const struct LFSx_API(config) *c, int cmd, int arg, bool must_return_int) {
+STATIC int MP_VFS_LFSx(dev_ioctl)(const struct LFSx_API (config) * c, int cmd, int arg, bool must_return_int) {
     mp_obj_t ret = mp_vfs_blockdev_ioctl(c->context, cmd, arg);
     int ret_i = 0;
     if (must_return_int || ret != mp_const_none) {
@@ -43,27 +43,27 @@ STATIC int MP_VFS_LFSx(dev_ioctl)(const struct LFSx_API(config) *c, int cmd, int
     return ret_i;
 }
 
-STATIC int MP_VFS_LFSx(dev_read)(const struct LFSx_API(config) *c, LFSx_API(block_t) block, LFSx_API(off_t) off, void *buffer, LFSx_API(size_t) size) {
+STATIC int MP_VFS_LFSx(dev_read)(const struct LFSx_API (config) * c, LFSx_API(block_t) block, LFSx_API(off_t) off, void *buffer, LFSx_API(size_t) size) {
     return mp_vfs_blockdev_read_ext(c->context, block, off, size, buffer);
 }
 
-STATIC int MP_VFS_LFSx(dev_prog)(const struct LFSx_API(config) *c, LFSx_API(block_t) block, LFSx_API(off_t) off, const void *buffer, LFSx_API(size_t) size) {
+STATIC int MP_VFS_LFSx(dev_prog)(const struct LFSx_API (config) * c, LFSx_API(block_t) block, LFSx_API(off_t) off, const void *buffer, LFSx_API(size_t) size) {
     return mp_vfs_blockdev_write_ext(c->context, block, off, size, buffer);
 }
 
-STATIC int MP_VFS_LFSx(dev_erase)(const struct LFSx_API(config) *c, LFSx_API(block_t) block) {
+STATIC int MP_VFS_LFSx(dev_erase)(const struct LFSx_API (config) * c, LFSx_API(block_t) block) {
     return MP_VFS_LFSx(dev_ioctl)(c, MP_BLOCKDEV_IOCTL_BLOCK_ERASE, block, true);
 }
 
-STATIC int MP_VFS_LFSx(dev_sync)(const struct LFSx_API(config) *c) {
+STATIC int MP_VFS_LFSx(dev_sync)(const struct LFSx_API (config) * c) {
     return MP_VFS_LFSx(dev_ioctl)(c, MP_BLOCKDEV_IOCTL_SYNC, 0, false);
 }
 
-STATIC void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx *self, mp_obj_t bdev, size_t read_size, size_t prog_size, size_t lookahead) {
+STATIC void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx * self, mp_obj_t bdev, size_t read_size, size_t prog_size, size_t lookahead) {
     self->blockdev.flags = MP_BLOCKDEV_FLAG_FREE_OBJ;
     mp_vfs_blockdev_init(&self->blockdev, bdev);
 
-    struct LFSx_API(config) *config = &self->config;
+    struct LFSx_API (config) * config = &self->config;
     memset(config, 0, sizeof(*config));
 
     config->context = &self->blockdev;
@@ -73,7 +73,7 @@ STATIC void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx *self, mp_obj_t bdev, size_
     config->erase = MP_VFS_LFSx(dev_erase);
     config->sync = MP_VFS_LFSx(dev_sync);
 
-    MP_VFS_LFSx(dev_ioctl)(config, MP_BLOCKDEV_IOCTL_INIT, 0, false); // initialise block device
+    MP_VFS_LFSx(dev_ioctl)(config, MP_BLOCKDEV_IOCTL_INIT, 1, false); // initialise block device
     int bs = MP_VFS_LFSx(dev_ioctl)(config, MP_BLOCKDEV_IOCTL_BLOCK_SIZE, 0, true); // get block size
     int bc = MP_VFS_LFSx(dev_ioctl)(config, MP_BLOCKDEV_IOCTL_BLOCK_COUNT, 0, true); // get block count
     self->blockdev.block_size = bs;
@@ -98,7 +98,7 @@ STATIC void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx *self, mp_obj_t bdev, size_
     #endif
 }
 
-const char *MP_VFS_LFSx(make_path)(MP_OBJ_VFS_LFSx *self, mp_obj_t path_in) {
+const char *MP_VFS_LFSx(make_path)(MP_OBJ_VFS_LFSx * self, mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     if (path[0] != '/') {
         size_t l = vstr_len(&self->cur_dir);
@@ -111,7 +111,7 @@ const char *MP_VFS_LFSx(make_path)(MP_OBJ_VFS_LFSx *self, mp_obj_t path_in) {
     return path;
 }
 
-STATIC mp_obj_t MP_VFS_LFSx(make_new)(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+STATIC mp_obj_t MP_VFS_LFSx(make_new)(const mp_obj_type_t * type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_val_t args[MP_ARRAY_SIZE(lfs_make_allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(lfs_make_allowed_args), lfs_make_allowed_args, args);
 
@@ -147,7 +147,7 @@ STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(MP_VFS_LFSx(mkfs_obj), MP_ROM_PTR(&MP_VF
 // Implementation of mp_vfs_lfs_file_open is provided in vfs_lfsx_file.c
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(MP_VFS_LFSx(open_obj), MP_VFS_LFSx(file_open));
 
-typedef struct MP_VFS_LFSx(_ilistdir_it_t) {
+typedef struct MP_VFS_LFSx (_ilistdir_it_t) {
     mp_obj_base_t base;
     mp_fun_1_t iternext;
     bool is_str;
@@ -156,9 +156,9 @@ typedef struct MP_VFS_LFSx(_ilistdir_it_t) {
 } MP_VFS_LFSx(ilistdir_it_t);
 
 STATIC mp_obj_t MP_VFS_LFSx(ilistdir_it_iternext)(mp_obj_t self_in) {
-    MP_VFS_LFSx(ilistdir_it_t) *self = MP_OBJ_TO_PTR(self_in);
+    MP_VFS_LFSx(ilistdir_it_t) * self = MP_OBJ_TO_PTR(self_in);
 
-    struct LFSx_API(info) info;
+    struct LFSx_API (info) info;
     for (;;) {
         int ret = LFSx_API(dir_read)(&self->vfs->lfs, &self->dir, &info);
         if (ret == 0) {
@@ -166,7 +166,7 @@ STATIC mp_obj_t MP_VFS_LFSx(ilistdir_it_iternext)(mp_obj_t self_in) {
             return MP_OBJ_STOP_ITERATION;
         }
         if (!(info.name[0] == '.' && (info.name[1] == '\0'
-            || (info.name[1] == '.' && info.name[2] == '\0')))) {
+                                      || (info.name[1] == '.' && info.name[2] == '\0')))) {
             break;
         }
     }
@@ -176,7 +176,7 @@ STATIC mp_obj_t MP_VFS_LFSx(ilistdir_it_iternext)(mp_obj_t self_in) {
     if (self->is_str) {
         t->items[0] = mp_obj_new_str(info.name, strlen(info.name));
     } else {
-        t->items[0] = mp_obj_new_bytes((const byte*)info.name, strlen(info.name));
+        t->items[0] = mp_obj_new_bytes((const byte *)info.name, strlen(info.name));
     }
     t->items[1] = MP_OBJ_NEW_SMALL_INT(info.type == LFSx_MACRO(_TYPE_REG) ? MP_S_IFREG : MP_S_IFDIR);
     t->items[2] = MP_OBJ_NEW_SMALL_INT(0); // no inode number
@@ -198,7 +198,7 @@ STATIC mp_obj_t MP_VFS_LFSx(ilistdir_func)(size_t n_args, const mp_obj_t *args) 
         path = vstr_null_terminated_str(&self->cur_dir);
     }
 
-    MP_VFS_LFSx(ilistdir_it_t) *iter = m_new_obj(MP_VFS_LFSx(ilistdir_it_t));
+    MP_VFS_LFSx(ilistdir_it_t) * iter = m_new_obj(MP_VFS_LFSx(ilistdir_it_t));
     iter->base.type = &mp_type_polymorph_iter;
     iter->iternext = MP_VFS_LFSx(ilistdir_it_iternext);
     iter->is_str = is_str_type;
@@ -236,10 +236,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(MP_VFS_LFSx(rmdir_obj), MP_VFS_LFSx(rmdir));
 STATIC mp_obj_t MP_VFS_LFSx(rename)(mp_obj_t self_in, mp_obj_t path_old_in, mp_obj_t path_new_in) {
     MP_OBJ_VFS_LFSx *self = MP_OBJ_TO_PTR(self_in);
     const char *path_old = MP_VFS_LFSx(make_path)(self, path_old_in);
+    const char *path = mp_obj_str_get_str(path_new_in);
     vstr_t path_new;
     vstr_init(&path_new, vstr_len(&self->cur_dir));
-    vstr_add_strn(&path_new, vstr_str(&self->cur_dir), vstr_len(&self->cur_dir));
-    vstr_add_str(&path_new, mp_obj_str_get_str(path_new_in));
+    if (path[0] != '/') {
+        vstr_add_strn(&path_new, vstr_str(&self->cur_dir), vstr_len(&self->cur_dir));
+    }
+    vstr_add_str(&path_new, path);
     int ret = LFSx_API(rename)(&self->lfs, path_old, vstr_null_terminated_str(&path_new));
     vstr_clear(&path_new);
     if (ret < 0) {
@@ -267,7 +270,7 @@ STATIC mp_obj_t MP_VFS_LFSx(chdir)(mp_obj_t self_in, mp_obj_t path_in) {
     const char *path = MP_VFS_LFSx(make_path)(self, path_in);
     if (path[1] != '\0') {
         // Not at root, check it exists
-        struct LFSx_API(info) info;
+        struct LFSx_API (info) info;
         int ret = LFSx_API(stat)(&self->lfs, path, &info);
         if (ret < 0 || info.type != LFSx_MACRO(_TYPE_DIR)) {
             mp_raise_OSError(-MP_ENOENT);
@@ -283,8 +286,34 @@ STATIC mp_obj_t MP_VFS_LFSx(chdir)(mp_obj_t self_in, mp_obj_t path_in) {
     }
 
     // If not at root add trailing / to make it easy to build paths
+    // and normalize the path
     if (vstr_len(&self->cur_dir) != 1) {
         vstr_add_byte(&self->cur_dir, '/');
+
+        #define CWD_LEN (vstr_len(&self->cur_dir))   
+        size_t to = 1; 
+        size_t from = 1;
+        char *cwd = vstr_str(&self->cur_dir);
+        while (from < CWD_LEN) {
+            for (; cwd[from] == '/' && from < CWD_LEN; from ++) ; // scan for the start
+            if (from > to) { // found excessive slash chars, squeeze them out
+                vstr_cut_out_bytes(&self->cur_dir, to, from - to);
+                from = to;
+            }
+            for (; cwd[from] != '/' && from < CWD_LEN; from++) ; // scan for the next /
+            if ((from - to) == 1 && cwd[to] == '.') { // './', ignore
+                vstr_cut_out_bytes(&self->cur_dir, to, ++from - to);
+                from = to;
+            } else if ((from - to) == 2 && cwd[to] == '.' && cwd[to + 1] == '.') { // '../', skip back
+                if (to > 1) {  // at the tip do not skip back
+                    for (--to; to > 1 && cwd[to - 1] != '/'; to--) ; // skip back
+                }
+                vstr_cut_out_bytes(&self->cur_dir, to, ++from - to);
+                from = to;
+            } else { // normal element, keep it and just move the offset
+                to = ++from;
+            }
+        }
     }
 
     return mp_const_none;
@@ -304,8 +333,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(MP_VFS_LFSx(getcwd_obj), MP_VFS_LFSx(getcwd));
 
 STATIC mp_obj_t MP_VFS_LFSx(stat)(mp_obj_t self_in, mp_obj_t path_in) {
     MP_OBJ_VFS_LFSx *self = MP_OBJ_TO_PTR(self_in);
-    const char *path = mp_obj_str_get_str(path_in);
-    struct LFSx_API(info) info;
+    const char *path = MP_VFS_LFSx(make_path)(self, path_in);
+    struct LFSx_API (info) info;
     int ret = LFSx_API(stat)(&self->lfs, path, &info);
     if (ret < 0) {
         mp_raise_OSError(-ret);
@@ -329,7 +358,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(MP_VFS_LFSx(stat_obj), MP_VFS_LFSx(stat));
 
 STATIC int LFSx_API(traverse_cb)(void *data, LFSx_API(block_t) bl) {
     (void)bl;
-    uint32_t *n = (uint32_t*)data;
+    uint32_t *n = (uint32_t *)data;
     *n += 1;
     return LFSx_MACRO(_ERR_OK);
 }
@@ -399,7 +428,7 @@ STATIC MP_DEFINE_CONST_DICT(MP_VFS_LFSx(locals_dict), MP_VFS_LFSx(locals_dict_ta
 
 STATIC mp_import_stat_t MP_VFS_LFSx(import_stat)(void *self_in, const char *path) {
     MP_OBJ_VFS_LFSx *self = self_in;
-    struct LFSx_API(info) info;
+    struct LFSx_API (info) info;
     int ret = LFSx_API(stat)(&self->lfs, path, &info);
     if (ret == 0) {
         if (info.type == LFSx_MACRO(_TYPE_REG)) {
@@ -424,5 +453,5 @@ const mp_obj_type_t MP_TYPE_VFS_LFSx = {
     #endif
     .make_new = MP_VFS_LFSx(make_new),
     .protocol = &MP_VFS_LFSx(proto),
-    .locals_dict = (mp_obj_dict_t*)&MP_VFS_LFSx(locals_dict),
+    .locals_dict = (mp_obj_dict_t *)&MP_VFS_LFSx(locals_dict),
 };

--- a/tests/extmod/vfs_lfs.py
+++ b/tests/extmod/vfs_lfs.py
@@ -2,11 +2,13 @@
 
 try:
     import uos
+
     uos.VfsLfs1
     uos.VfsLfs2
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
+
 
 class RAMBlockDevice:
     ERASE_BLOCK_SIZE = 1024
@@ -25,15 +27,16 @@ class RAMBlockDevice:
             self.data[addr + i] = buf[i]
 
     def ioctl(self, op, arg):
-        if op == 4: # block count
+        if op == 4:  # block count
             return len(self.data) // self.ERASE_BLOCK_SIZE
-        if op == 5: # block size
+        if op == 5:  # block size
             return self.ERASE_BLOCK_SIZE
-        if op == 6: # erase block
+        if op == 6:  # erase block
             return 0
 
+
 def test(bdev, vfs_class):
-    print('test', vfs_class)
+    print("test", vfs_class)
 
     # mkfs
     vfs_class.mkfs(bdev)
@@ -42,65 +45,96 @@ def test(bdev, vfs_class):
     vfs = vfs_class(bdev)
 
     # statvfs
-    print(vfs.statvfs('/'))
+    print(vfs.statvfs("/"))
 
     # open, write close
-    f = vfs.open('test', 'w')
-    f.write('littlefs')
+    f = vfs.open("test", "w")
+    f.write("littlefs")
     f.close()
 
     # statvfs after creating a file
-    print(vfs.statvfs('/'))
+    print(vfs.statvfs("/"))
 
     # ilistdir
     print(list(vfs.ilistdir()))
-    print(list(vfs.ilistdir('/')))
-    print(list(vfs.ilistdir(b'/')))
+    print(list(vfs.ilistdir("/")))
+    print(list(vfs.ilistdir(b"/")))
 
     # mkdir, rmdir
-    vfs.mkdir('testdir')
+    vfs.mkdir("testdir")
     print(list(vfs.ilistdir()))
-    print(list(vfs.ilistdir('testdir')))
-    vfs.rmdir('testdir')
+    print(sorted(list(vfs.ilistdir("testdir"))))
+    vfs.rmdir("testdir")
     print(list(vfs.ilistdir()))
-    vfs.mkdir('testdir')
+    vfs.mkdir("testdir")
 
     # stat a file
-    print(vfs.stat('test'))
+    print(vfs.stat("test"))
 
     # stat a dir (size seems to vary on LFS2 so don't print that)
-    print(vfs.stat('testdir')[:6])
+    print(vfs.stat("testdir")[:6])
 
     # read
-    with vfs.open('test', 'r') as f:
+    with vfs.open("test", "r") as f:
         print(f.read())
 
     # create large file
-    with vfs.open('testbig', 'w') as f:
-        data = 'large012' * 32 * 16
-        print('data length:', len(data))
+    with vfs.open("testbig", "w") as f:
+        data = "large012" * 32 * 16
+        print("data length:", len(data))
         for i in range(4):
-            print('write', i)
+            print("write", i)
             f.write(data)
 
     # stat after creating large file
-    print(vfs.statvfs('/'))
+    print(vfs.statvfs("/"))
 
     # rename
-    vfs.rename('testbig', 'testbig2')
-    print(list(vfs.ilistdir()))
+    vfs.rename("testbig", "testbig2")
+    print(sorted(list(vfs.ilistdir())))
+    vfs.chdir("testdir")
+    vfs.rename("/testbig2", "testbig2")
+    print(sorted(list(vfs.ilistdir())))
+    vfs.rename("testbig2", "/testbig2")
+    vfs.chdir("/")
+    print(sorted(list(vfs.ilistdir())))
 
     # remove
-    vfs.remove('testbig2')
-    print(list(vfs.ilistdir()))
+    vfs.remove("testbig2")
+    print(sorted(list(vfs.ilistdir())))
 
     # getcwd, chdir
+    vfs.mkdir("/testdir2")
+    vfs.mkdir("/testdir/subdir")
     print(vfs.getcwd())
-    vfs.chdir('/testdir')
+    vfs.chdir("/testdir")
     print(vfs.getcwd())
-    vfs.chdir('/')
+    vfs.chdir("/")
     print(vfs.getcwd())
-    vfs.rmdir('testdir')
+    vfs.chdir("testdir")
+    print(vfs.getcwd())
+    vfs.chdir("..")
+    print(vfs.getcwd())
+    vfs.chdir("testdir/subdir")
+    print(vfs.getcwd())
+    vfs.chdir("../..")
+    print(vfs.getcwd())
+    vfs.chdir("/./testdir2")
+    print(vfs.getcwd())
+    vfs.chdir("../testdir")
+    print(vfs.getcwd())
+    vfs.chdir("../..")
+    print(vfs.getcwd())
+    vfs.chdir(".//testdir")
+    print(vfs.getcwd())
+    vfs.chdir("subdir/./")
+    print(vfs.getcwd())
+    vfs.chdir("/")
+    print(vfs.getcwd())
+    vfs.rmdir("testdir/subdir")
+    vfs.rmdir("testdir")
+    vfs.rmdir("testdir2")
+
 
 bdev = RAMBlockDevice(30)
 test(bdev, uos.VfsLfs1)

--- a/tests/extmod/vfs_lfs.py.exp
+++ b/tests/extmod/vfs_lfs.py.exp
@@ -16,10 +16,22 @@ write 1
 write 2
 write 3
 (1024, 1024, 30, 6, 6, 0, 0, 0, 0, 255)
-[('test', 32768, 0, 8), ('testdir', 16384, 0, 0), ('testbig2', 32768, 0, 16384)]
+[('test', 32768, 0, 8), ('testbig2', 32768, 0, 16384), ('testdir', 16384, 0, 0)]
+[('testbig2', 32768, 0, 16384)]
+[('test', 32768, 0, 8), ('testbig2', 32768, 0, 16384), ('testdir', 16384, 0, 0)]
 [('test', 32768, 0, 8), ('testdir', 16384, 0, 0)]
 /
 /testdir
+/
+/testdir
+/
+/testdir/subdir
+/
+/testdir2
+/testdir
+/
+/testdir
+/testdir/subdir
 /
 test <class 'VfsLfs2'>
 (1024, 1024, 30, 28, 28, 0, 0, 0, 0, 255)
@@ -38,9 +50,24 @@ write 0
 write 1
 write 2
 write 3
-(1024, 1024, 30, 9, 9, 0, 0, 0, 0, 255)
-[('testbig2', 32768, 0, 16384), ('testdir', 16384, 0, 0), ('test', 32768, 0, 8)]
-[('testdir', 16384, 0, 0), ('test', 32768, 0, 8)]
+(1024, 1024, 30, 7, 7, 0, 0, 0, 0, 255)
+[('test', 32768, 0, 8), ('testbig2', 32768, 0, 16384), ('testdir', 16384, 0, 0)]
+[('testbig2', 32768, 0, 16384)]
+[('test', 32768, 0, 8), ('testbig2', 32768, 0, 16384), ('testdir', 16384, 0, 0)]
+[('test', 32768, 0, 8), ('testdir', 16384, 0, 0)]
 /
 /testdir
+/
+/
+/testdir
+/
+/testdir
+/
+/testdir/subdir
+/
+/testdir2
+/testdir
+/
+/testdir
+/testdir/subdir
 /


### PR DESCRIPTION
- when calling uos.stat() on a file in a subdirectory with a relative path,
  the directory /flash was searched for that file. So with "testfile" in
  a directory "testdir", uos.stat("testfile") failed, when the current
  dir was "/flash/testdir". Fixed now.
- when calling rename with an absolute path for the second file, this
  path was appended to the current dir name, instead of taking that
  absolute path name. So with "testfile" in a directory "testdir",
  uos.rename("testfile", "/flash/newfile") failed, when the current
  dir was "/flash/testdir". Fixed now.
- when given a relative path, chdir appended that new path to the
  actual current dir and did not normlize the path name. So when the
  current dir was /flash/testdir, uos.chdir("..") caused to current dir
  to get /flash/testdir/.. With that change, current dir will then be
  /flash.

The test file for coverage tests are changed too.