### PR TITLE
extmod/vfs_lfsx.c: Setting the full path in import_stat()

### DIFF
--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -31,6 +31,7 @@
 #include "py/stream.h"
 #include "py/binary.h"
 #include "py/objarray.h"
+#include "py/objstr.h"
 #include "py/mperrno.h"
 #include "extmod/vfs.h"
 
@@ -286,31 +287,42 @@ STATIC mp_obj_t MP_VFS_LFSx(chdir)(mp_obj_t self_in, mp_obj_t path_in) {
     }
 
     // If not at root add trailing / to make it easy to build paths
-    // and normalize the path
+    // and then normalise the path
     if (vstr_len(&self->cur_dir) != 1) {
         vstr_add_byte(&self->cur_dir, '/');
 
-        #define CWD_LEN (vstr_len(&self->cur_dir))   
-        size_t to = 1; 
+        #define CWD_LEN (vstr_len(&self->cur_dir))
+        size_t to = 1;
         size_t from = 1;
         char *cwd = vstr_str(&self->cur_dir);
         while (from < CWD_LEN) {
-            for (; cwd[from] == '/' && from < CWD_LEN; from ++) ; // scan for the start
-            if (from > to) { // found excessive slash chars, squeeze them out
+            for (; cwd[from] == '/' && from < CWD_LEN; ++from) {
+                // Scan for the start
+            }
+            if (from > to) {
+                // Found excessive slash chars, squeeze them out
                 vstr_cut_out_bytes(&self->cur_dir, to, from - to);
                 from = to;
             }
-            for (; cwd[from] != '/' && from < CWD_LEN; from++) ; // scan for the next /
-            if ((from - to) == 1 && cwd[to] == '.') { // './', ignore
+            for (; cwd[from] != '/' && from < CWD_LEN; ++from) {
+                // Scan for the next /
+            }
+            if ((from - to) == 1 && cwd[to] == '.') {
+                // './', ignore
                 vstr_cut_out_bytes(&self->cur_dir, to, ++from - to);
                 from = to;
-            } else if ((from - to) == 2 && cwd[to] == '.' && cwd[to + 1] == '.') { // '../', skip back
-                if (to > 1) {  // at the tip do not skip back
-                    for (--to; to > 1 && cwd[to - 1] != '/'; to--) ; // skip back
+            } else if ((from - to) == 2 && cwd[to] == '.' && cwd[to + 1] == '.') {
+                // '../', skip back
+                if (to > 1) {
+                    // Only skip back if not at the tip
+                    for (--to; to > 1 && cwd[to - 1] != '/'; --to) {
+                        // Skip back
+                    }
                 }
                 vstr_cut_out_bytes(&self->cur_dir, to, ++from - to);
                 from = to;
-            } else { // normal element, keep it and just move the offset
+            } else {
+                // Normal element, keep it and just move the offset
                 to = ++from;
             }
         }
@@ -429,6 +441,8 @@ STATIC MP_DEFINE_CONST_DICT(MP_VFS_LFSx(locals_dict), MP_VFS_LFSx(locals_dict_ta
 STATIC mp_import_stat_t MP_VFS_LFSx(import_stat)(void *self_in, const char *path) {
     MP_OBJ_VFS_LFSx *self = self_in;
     struct LFSx_API (info) info;
+    mp_obj_str_t path_obj = { { &mp_type_str }, 0, 0, (const byte *)path };
+    path = MP_VFS_LFSx(make_path)(self, &path_obj);
     int ret = LFSx_API(stat)(&self->lfs, path, &info);
     if (ret == 0) {
         if (info.type == LFSx_MACRO(_TYPE_REG)) {


### PR DESCRIPTION
That was missing and caused import to fail sometimes if
the module was located in a subdirectory. Fixed by Damien George.

Also: Some reformatting done by uncrustify.