### PR TITLE
qstrdefsport.h, main.c: Fix adding paths to sys.path

### DIFF
--- a/ports/w60x/main.c
+++ b/ports/w60x/main.c
@@ -221,7 +221,8 @@ soft_reset:
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
-    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_flash_slash_lib));
     mp_obj_list_init(mp_sys_argv, 0);
     readline_init0();
     timer_init0();

--- a/ports/w60x/qstrdefsport.h
+++ b/ports/w60x/qstrdefsport.h
@@ -24,3 +24,6 @@
  * THE SOFTWARE.
  */
 
+// Entries for sys.path
+Q(/flash)
+Q(/flash/lib)


### PR DESCRIPTION
The path strings have to be added to qstrdefsport.h such that get
properly expanded.